### PR TITLE
fix 'disable reload prompt' feature

### DIFF
--- a/holochrome/disableReload.js
+++ b/holochrome/disableReload.js
@@ -1,2 +1,2 @@
 console.log('Holochrome is disabling the AWS Console force reload dialog');
-AWSC.jQuery(AWSC).trigger("cancel-auth-change-detect");
+window.dispatchEvent(new Event('cancel-auth-change-detect'));


### PR DESCRIPTION
current version of the console shows this behavior:

```
Holochrome is disabling the AWS Console force reload dialog
disableReload.js:2 Uncaught TypeError: AWSC.jQuery is not a function
    at disableReload.js:2
```

There is an event listener on `window` for this event:

```
getEventListeners(window)['cancel-auth-change-detect']
[{…}]
0: {useCapture: false, passive: false, once: false, type: "cancel-auth-change-detect", listener: ƒ}
length: 1
__proto__: Array(0)
```

And so I believe (but have not yet confirmed) that this change will
have the same effect.

TODO:
  - [ ] verify this actually works