### PR TITLE
[SRE-3808] Manifest v3 migration

### DIFF
--- a/holochrome/inject.js
+++ b/holochrome/inject.js
@@ -1,5 +1,7 @@
 (function() {
     var s = document.createElement('script');
+    // DEPRECATION: chrome.extension.getURL is deprecated in Manifest v3
+    //   see full details here: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
     s.src = chrome.extension.getURL('disableReload.js');
     s.onload = function() {
         this.parentNode.removeChild(this);

--- a/holochrome/manifest.json
+++ b/holochrome/manifest.json
@@ -31,12 +31,10 @@
         "128": "holochrome-128.png"
     },
     "background": {
-        "scripts": [
-            "script.js"
-        ]
+        "service_worker": "script.js"
     },
-    "version": "1.6",
-    "manifest_version": 2,
+    "version": "2.0",
+    "manifest_version": 333,
     "permissions": [
         "notifications",
         "webRequest"

--- a/holochrome/manifest.json
+++ b/holochrome/manifest.json
@@ -12,7 +12,7 @@
             "description": "Open a tab to AWS console"
         }
     },
-    "browser_action": {
+    "action": {
         "name": "Click to open AWS Console. Or press Cmd+Shift+1.",
         "default_icon": "holochrome-128.png"
     },
@@ -39,7 +39,9 @@
     "manifest_version": 2,
     "permissions": [
         "notifications",
-        "webRequest",
+        "webRequest"
+    ],
+    "host_permissions": [
         "https://signin.aws.amazon.com/federation",
         "https://*.signin.aws.amazon.com/oauth",
         "http://169.254.169.254/*",

--- a/holochrome/script.js
+++ b/holochrome/script.js
@@ -128,7 +128,7 @@ var eventTriggered = function(arg) {
 
 chrome.commands.onCommand.addListener(eventTriggered);
 
-chrome.browserAction.onClicked.addListener(eventTriggered);
+chrome.action.onClicked.addListener(eventTriggered);
 
 var init = (function(){
   getMyCreds(false);


### PR DESCRIPTION
Manifest v3 introduces a wide range of breaking changes for Chrome extensions, many of which hit Holochrome's implementation.

This PR is a first pass at resolving breaking changes to create a functional Manifest v3 version before the deadline of June 2022.

**Draft PR Notes** 

This will require a significant refactor due to deprecation of:

- background pages (superceded by [Service Workers](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#service-workers))
- `chrome.extension.getURL()` API