### PR TITLE
Fix Chrome Web Store link to NextRoll private edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Holochrome is a chrome extension that allows you to easily spawn an AWS GUI sess
 
 # How do I get it?
 
-Chrome: [Chrome Web Store](https://chrome.google.com/webstore/detail/holochrome/fgnplojdffjfbcmoldcfdoikldnogjpa)
+Chrome: [Chrome Web Store](https://chrome.google.com/webstore/detail/holochrome/papjogngcdoogibgbongjmiakldjhpok)
 
 Firefox: [Mozilla Add-on Store](https://addons.mozilla.org/en-US/firefox/addon/bw-holochrome)
 


### PR DESCRIPTION
Our NextRoll fork was using the upstream's link to the Chrome Web Store. I've replaced this on the "About" section with the private link, as well as in the `README`

