### PR TITLE
Chrome Manifest v3

### DIFF
--- a/holochrome/inject.js
+++ b/holochrome/inject.js
@@ -1,6 +1,6 @@
 (function() {
     var s = document.createElement('script');
-    s.src = chrome.extension.getURL('disableReload.js');
+    s.src = chrome.runtime.getURL('disableReload.js');
     s.onload = function() {
         this.parentNode.removeChild(this);
     };

--- a/holochrome/manifest.json
+++ b/holochrome/manifest.json
@@ -1,7 +1,13 @@
 {
-    "web_accessible_resources": [
-        "disableReload.js"
-    ],
+    "web_accessible_resources": [{
+        "resources": [
+          "disableReload.js"
+        ],
+        "matches": [
+          "https://console.aws.amazon.com/*",
+          "https://*.console.aws.amazon.com/*"
+        ]
+    }],
     "commands": {
         "open-console": {
             "global": true,
@@ -12,7 +18,7 @@
             "description": "Open a tab to AWS console"
         }
     },
-    "browser_action": {
+    "action": {
         "name": "Click to open AWS Console. Or press Cmd+Shift+1.",
         "default_icon": "holochrome-128.png"
     },
@@ -31,15 +37,15 @@
         "128": "holochrome-128.png"
     },
     "background": {
-        "scripts": [
-            "script.js"
-        ]
+        "service_worker": "script.js"
     },
-    "version": "1.6",
-    "manifest_version": 2,
+    "version": "1.7",
+    "manifest_version": 3,
     "permissions": [
         "notifications",
-        "webRequest",
+        "webRequest"
+    ],
+    "host_permissions": [
         "https://signin.aws.amazon.com/federation",
         "https://*.signin.aws.amazon.com/oauth",
         "http://169.254.169.254/*",


### PR DESCRIPTION
See Chrome manifest v3 migration guide: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/

Many minor changes were made according to the migration guide. The most important change in this PR, however, is the change from using the deprecated `XMLHttpRequest` to using the native Javascript asynchronous `fetch` function and promises.

Tested and working on my laptop. 

Updates to v1.7. 